### PR TITLE
feat: add angular pomodoro timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+.tmp/
+.cache/
+.angular/cache
+
+# Mac, Linux, Windows extras
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Pomodoro Time Angular
+
+Simple Pomodoro timer built with Angular and TypeScript. The app showcases components, services and RxJS observables.
+
+## Development
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm start
+   ```
+
+3. Run unit tests:
+
+   ```bash
+   npm test
+   ```

--- a/angular.json
+++ b/angular.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "pomodoro-time-angular": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/pomodoro-time-angular",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.app.json",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.css"
+            ],
+            "scripts": []
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "pomodoro-time-angular:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.css"
+            ],
+            "scripts": []
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "pomodoro-time-angular"
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,29 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['ChromeHeadless'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "pomodoro-time-angular",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.3.0",
+    "@angular/common": "^17.3.0",
+    "@angular/compiler": "^17.3.0",
+    "@angular/core": "^17.3.0",
+    "@angular/forms": "^17.3.0",
+    "@angular/platform-browser": "^17.3.0",
+    "@angular/platform-browser-dynamic": "^17.3.0",
+    "@angular/router": "^17.3.0",
+    "rxjs": "~7.8.0",
+    "tslib": "^2.3.0",
+    "zone.js": "~0.14.0"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.3.0",
+    "@angular/cli": "^17.3.0",
+    "@angular/compiler-cli": "^17.3.0",
+    "@types/jasmine": "~5.1.0",
+    "jasmine-core": "~5.1.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.0.0",
+    "typescript": "~5.3.0"
+  }
+}

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,3 @@
+.app-container {
+  text-align: center;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,3 @@
+<div class="app-container">
+  <app-pomodoro-timer></app-pomodoro-timer>
+</div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+export class AppComponent {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+
+import { AppComponent } from './app.component';
+import { PomodoroTimerComponent } from './pomodoro/pomodoro-timer.component';
+
+@NgModule({
+  declarations: [AppComponent, PomodoroTimerComponent],
+  imports: [BrowserModule, FormsModule],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/src/app/pomodoro/pomodoro-timer.component.css
+++ b/src/app/pomodoro/pomodoro-timer.component.css
@@ -1,0 +1,25 @@
+.pomodoro {
+  text-align: center;
+}
+
+.display {
+  font-size: 3rem;
+  margin: 1rem 0;
+}
+
+.controls button {
+  margin: 0 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}
+
+.settings {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.settings input {
+  width: 3rem;
+}

--- a/src/app/pomodoro/pomodoro-timer.component.html
+++ b/src/app/pomodoro/pomodoro-timer.component.html
@@ -1,0 +1,12 @@
+<div class="pomodoro">
+  <h2>{{ mode === 'work' ? 'Work Session' : 'Break Session' }}</h2>
+  <div class="display">{{ formatTime((remaining$ | async) ?? 0) }}</div>
+  <div class="controls">
+    <button (click)="start()">Start</button>
+    <button (click)="pause()">Pause</button>
+  </div>
+  <div class="settings">
+    <label>Work (min): <input type="number" [(ngModel)]="workDuration" min="1"></label>
+    <label>Break (min): <input type="number" [(ngModel)]="breakDuration" min="1"></label>
+  </div>
+</div>

--- a/src/app/pomodoro/pomodoro-timer.component.spec.ts
+++ b/src/app/pomodoro/pomodoro-timer.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { PomodoroTimerComponent } from './pomodoro-timer.component';
+
+describe('PomodoroTimerComponent', () => {
+  let component: PomodoroTimerComponent;
+  let fixture: ComponentFixture<PomodoroTimerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PomodoroTimerComponent],
+      imports: [FormsModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PomodoroTimerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pomodoro/pomodoro-timer.component.ts
+++ b/src/app/pomodoro/pomodoro-timer.component.ts
@@ -1,0 +1,58 @@
+import { Component, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { PomodoroService } from './pomodoro.service';
+
+@Component({
+  selector: 'app-pomodoro-timer',
+  templateUrl: './pomodoro-timer.component.html',
+  styleUrls: ['./pomodoro-timer.component.css']
+})
+export class PomodoroTimerComponent implements OnDestroy {
+  workDuration = 25;
+  breakDuration = 5;
+  mode: 'work' | 'break' = 'work';
+  remaining$ = this.pomodoro.remaining$;
+  private completionSub?: Subscription;
+
+  constructor(private pomodoro: PomodoroService) {}
+
+  start(): void {
+    this.cancelCompletionWatcher();
+    const duration = (this.mode === 'work' ? this.workDuration : this.breakDuration) * 60;
+    this.pomodoro.start(duration);
+    this.completionSub = this.remaining$.subscribe(v => {
+      if (v === 0) {
+        this.mode = this.mode === 'work' ? 'break' : 'work';
+        this.start();
+      }
+    });
+  }
+
+  pause(): void {
+    this.pomodoro.stop();
+    this.cancelCompletionWatcher();
+  }
+
+  reset(): void {
+    this.pause();
+    this.mode = 'work';
+    this.pomodoro.start(this.workDuration * 60);
+    this.pause();
+  }
+
+  private cancelCompletionWatcher(): void {
+    this.completionSub?.unsubscribe();
+    this.completionSub = undefined;
+  }
+
+  ngOnDestroy(): void {
+    this.pomodoro.stop();
+    this.cancelCompletionWatcher();
+  }
+
+  formatTime(totalSeconds: number): string {
+    const minutes = Math.floor(totalSeconds / 60).toString().padStart(2, '0');
+    const seconds = Math.floor(totalSeconds % 60).toString().padStart(2, '0');
+    return `${minutes}:${seconds}`;
+  }
+}

--- a/src/app/pomodoro/pomodoro.service.ts
+++ b/src/app/pomodoro/pomodoro.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, Subscription, interval, map, takeWhile } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class PomodoroService {
+  private remainingSubject = new BehaviorSubject<number>(0);
+  remaining$: Observable<number> = this.remainingSubject.asObservable();
+  private sub?: Subscription;
+
+  start(durationSeconds: number): void {
+    this.stop();
+    this.remainingSubject.next(durationSeconds);
+    this.sub = interval(1000)
+      .pipe(
+        map(elapsed => durationSeconds - elapsed - 1),
+        takeWhile(val => val >= 0)
+      )
+      .subscribe(val => this.remainingSubject.next(val));
+  }
+
+  stop(): void {
+    this.sub?.unsubscribe();
+    this.sub = undefined;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PomodoroTimeAngular</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,7 @@
+import 'zone.js';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,13 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.app-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,11 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es2022",
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "lib": [
+      "es2020",
+      "dom"
+    ]
+  }
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": [
+      "jasmine",
+      "node"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold Angular project for a front-end Pomodoro timer
- implement Pomodoro timer component and service using RxJS observables
- document project setup and development commands

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae497f7d308324a7dc904c30579bb9